### PR TITLE
fix: solved toast 조건별로 분기 설정

### DIFF
--- a/src/views/Member/index.js
+++ b/src/views/Member/index.js
@@ -89,7 +89,7 @@ const Member = () => {
   const { isLoggedIn } = useLoginState();
   const [memberDataPending, setMemberDataPending] = useState(false);
   const [showConfetti, setShowConfetti] = useState(false);
-  const loaddingMessage = Message();
+  const loadingMessage = Message();
   const coinMessage = Message();
   const [solvedStatus, setSolvedStatus] = useState('');
   const [rank, setRank] = useState(0);
@@ -163,7 +163,7 @@ const Member = () => {
   }
 
   const checkTodaySolvedProblem = () => {
-    loaddingMessage.show();
+    loadingMessage.show();
     serverAPI
       .post('/today-problem/solved', {}, { timeout: 300000 })
       .then(res => {
@@ -174,7 +174,7 @@ const Member = () => {
           setShowConfetti(true);
           setTimeout(() => setShowConfetti(false), 2000);
         }
-        loaddingMessage.hide();
+        loadingMessage.hide();
         coinMessage.show();
         setTimeout(() => coinMessage.hide(), 2000);
       })
@@ -199,7 +199,7 @@ const Member = () => {
   return (
     <MemberContainer>
       <TopBar active={true} />
-      {loaddingMessage.render({
+      {loadingMessage.render({
         icon: loadingIconWithBg,
         children: (
           <span


### PR DESCRIPTION
- solvedStatus의 상태(UNSOLVED, SOLVED, ALREADY_SOLVED)에 따라 `메세지`와 `confetti 노출 여부`가 달라지도록 수정하였습니다