### PR TITLE
fix: userCoin 반영 오류 수정

### DIFF
--- a/src/components/Message/CoinMessage/index.js
+++ b/src/components/Message/CoinMessage/index.js
@@ -5,13 +5,13 @@ import { HStack } from '../../../styles/Stack.styles';
 const CoinComponent = ({ userCoin, obtainCoin, triggerAnimation }) => {
   const [coin, setCoin] = useState(userCoin);
   const [isVisible, setIsVisible] = useState(true);
-  const plusCoinSpanRef = useRef();
+  const earnedCoinRef = useRef();
 
   useEffect(() => {
     if (triggerAnimation) {
       const fadeOutTimeout = setTimeout(() => {
         setIsVisible(false);
-        setCoin(userCoin + obtainCoin);
+        setCoin(prev => prev + obtainCoin);
       }, 2000);
 
       return () => {
@@ -19,6 +19,10 @@ const CoinComponent = ({ userCoin, obtainCoin, triggerAnimation }) => {
       };
     }
   }, [triggerAnimation]);
+
+  useEffect(() => {
+    setCoin(userCoin);
+  }, [userCoin]);
 
   return (
     <HStack
@@ -31,11 +35,7 @@ const CoinComponent = ({ userCoin, obtainCoin, triggerAnimation }) => {
       }}
     >
       <S.CurrentCoin isVisible={isVisible}>{coin}코인 </S.CurrentCoin>
-      <S.EarnedCoin
-        ref={plusCoinSpanRef}
-        isVisible={isVisible}
-        width={isVisible ? plusCoinSpanRef.current?.offsetWidth : 0}
-      >
+      <S.EarnedCoin ref={earnedCoinRef} isVisible={isVisible} width={isVisible ? 23 : 0}>
         +{obtainCoin}
       </S.EarnedCoin>
     </HStack>


### PR DESCRIPTION
### 수정사항
* coin state 업데이트가 안되는 오류를 수정했습니다.

### 문제상황
* 기존에는 earnedCoin의 width를 ref로 받아왔는데, obtainCoin의 초기값이 0이어서 "+0"의 width를 받아오게 돼서 간격이 좁게 설정됩니다.
* 그래서 obtainCoin이 바뀔 때 useEffect에서 ref로 width를 받아오려고 했는데, 이미 "+0"의 width로 고정되어서 그 길이를 받아와 반영이 안되는 것 같습니다.
* 임시방편으로 width를 우선 23("+00"의 width)으로 설정해놨습니다. 좋은 방법이 아닌 것 같아서 어떻게 하면 좋을까요?!