### PR TITLE
fix: 슬라이더 아이템 위치 에러 수정

### DIFF
--- a/src/views/Main/CourseContainer/SilderContainer/index.tsx
+++ b/src/views/Main/CourseContainer/SilderContainer/index.tsx
@@ -1,13 +1,15 @@
 import S from './style';
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useLayoutEffect } from 'react';
 import useUserCourse from './useUserCourse';
 import { moveToProblemSite } from '@/utils/index';
 import TodayProlemContainer from '../../TodayProlemContainer';
+import { useLocation } from 'react-router-dom';
 
 const SilderContainer = () => {
   const { courseIndex, setCourseIndex, todayProblem, courseList } = useUserCourse();
-  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+  const [windowWidth, setWindowWidth] = useState(0);
   const sliderItemRef = useRef<HTMLDivElement>(null);
+  const location = useLocation();
 
   const handleCourseClick = (index: number) => {
     if (courseIndex !== index) {
@@ -38,13 +40,18 @@ const SilderContainer = () => {
     return 0;
   };
 
+  useLayoutEffect(() => {
+    setWindowWidth(window.innerWidth);
+  }, [location.pathname]);
+
   useEffect(() => {
-    const handleResize = () => {
+    const updateWindowWidth = () => {
       setWindowWidth(window.innerWidth);
     };
 
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    updateWindowWidth();
+    window.addEventListener('resize', updateWindowWidth);
+    return () => window.removeEventListener('resize', updateWindowWidth);
   }, []);
 
   return (


### PR DESCRIPTION
## 변경 사항 설명
route 변경 시 메인페이지에서 슬라이더 아이템의 위치 계산이 되지 않는 에러를 수정하였습니다.

## 체크리스트
- [x] 아이템 위치 에러 수정
- [ ] 아이템 이동하는 현상 제거

## 추가 정보
- 심각하지는 않지만 courseIndex가 1인 상태로 route변경 시, 아이템이 이동하는 현상이 있습니다.
개발이 끝난 후 진행하면 될 것 같습니다.